### PR TITLE
feat: Add React support

### DIFF
--- a/src/integrations/minijinja.rs
+++ b/src/integrations/minijinja.rs
@@ -1,7 +1,7 @@
 //! This module implements the necessary traits required to make `crate::Vite`
 //! callable in minijinja templates.
 
-use crate::vite::Vite;
+use crate::vite::{Vite, ViteReactRefresh};
 
 use std::sync::Arc;
 
@@ -53,11 +53,48 @@ impl Object for Vite {
     }
 }
 
+/// Allows for instances fo ViteReactRefresh to be bound as values and added to the
+/// minijinja environment.
+///
+/// # Examples
+///
+/// ```
+/// use in_vite::{Vite, ViteReactRefresh};
+/// use minijinja::{Environment, Value, Error};
+///
+/// fn main() -> Result<(), Error> {
+///     let vite = Vite::default();
+///     let vite_react_refresh = ViteReactRefresh::new(vite.host());
+///     let mut env = Environment::new();
+///     env.add_global("vite_react_refresh", Value::from_object(vite_react_refresh));
+///
+///     let template = env.render_str(r#"{{ vite_react_refresh() }}"#, Value::UNDEFINED)?;
+///     Ok(())
+/// }
+///
+/// ```
+///
+impl Object for ViteReactRefresh {
+    fn repr(self: &Arc<Self>) -> ObjectRepr {
+        ObjectRepr::Plain
+    }
+
+    fn call(
+        self: &Arc<Self>,
+        _state: &minijinja::State<'_, '_>,
+        _args: &[minijinja::Value],
+    ) -> Result<Value, Error> {
+        let code = self.react_refresh();
+
+        Ok(Value::from_safe_string(code))
+    }
+}
+
 #[cfg(test)]
 mod test {
 
-    use super::Vite;
-    use crate::vite::{ViteOptions, ViteMode};
+    use super::{Vite, ViteReactRefresh};
+    use crate::vite::{ViteMode, ViteOptions};
     use minijinja::Environment;
     use minijinja::Value;
 
@@ -80,7 +117,7 @@ mod test {
             .expect("Should work.");
 
         let expected = r#"<script type="module" src="http://localhost:5173/@vite/client"></script>
-<script type="module" src="http://localhost:5173/@vite/main.js"></script>"#;
+<script type="module" src="http://localhost:5173/views/foo.js"></script>"#;
 
         assert_eq!(result, expected);
     }
@@ -105,6 +142,31 @@ mod test {
 <link rel="stylesheet" href="assets/shared-ChJ_j-JJ.css" />
 <script type="module" src="assets/foo-BRBmoGS9.js"></script>
 <link rel="modulepreload" href="assets/shared-B7PI925R.js" />"#;
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn can_minijinja_inject_react_refresh_development() {
+        let opts = ViteOptions::default()
+            .mode(ViteMode::Development)
+            .source(Some(SAMPLE_MANIFEST.to_string()));
+
+        let vite = Vite::with_options(opts);
+        let vite_react_refresh = ViteReactRefresh::new(vite.host());
+        let mut env = Environment::new();
+        env.add_global("vite_react_refresh", Value::from_object(vite_react_refresh));
+        let result = env
+            .render_str(r#"{{ vite_react_refresh() }}"#, Value::UNDEFINED)
+            .expect("Should work.");
+
+        let expected = r#"<script type="module">
+import RefreshRuntime from "http://localhost:5173/@react-refresh"
+RefreshRuntime.injectIntoGlobalHook(window)
+window.$RefreshReg$ = () => {}
+window.$RefreshSig$ = () => (type) => type
+window.__vite_plugin_react_preamble_installed__ = true
+</script>"#;
 
         assert_eq!(result, expected);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
 //! This module implements the necessary types and function required to
 //! integrate Vite into Rust backend projects.
 
+mod error;
 mod integrations;
 mod manifest;
 mod resource;
 mod vite;
-mod error;
 
-pub use vite::{ViteMode, ViteOptions, Vite};
-
+pub use vite::{Vite, ViteMode, ViteOptions, ViteReactRefresh};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -95,7 +95,7 @@ impl<'a> Manifest {
 
         if key.ends_with(".css") {
             resources.push(Resource::Stylesheet(&chunk.file));
-        } else if key.ends_with(".js") {
+        } else if key.ends_with(".js") || key.ends_with(".jsx") {
             resources.push(Resource::Module(&chunk.file));
         }
     }

--- a/src/vite.rs
+++ b/src/vite.rs
@@ -146,9 +146,26 @@ impl<'a> Vite {
 
     fn to_development_html(&'a self, entrypoints: Vec<&'a str>) -> String {
         let host = &self.host;
-        let mut lines: Vec<String> = vec![
-            format!(r#"<script type="module" src="{host}/@vite/client"></script>"#),
-        ];
+        let mut lines: Vec<String> = vec![format!(
+            r#"<script type="module" src="{host}/@vite/client"></script>"#
+        )];
+
+        let is_react = entrypoints
+            .iter()
+            .any(|&entrypoint| entrypoint.ends_with(".jsx"));
+        if is_react {
+            lines.push(format!(
+                r#"
+                    <script type="module">
+                        import RefreshRuntime from "{host}/@react-refresh"
+                        RefreshRuntime.injectIntoGlobalHook(window)
+                        window.$RefreshReg$ = () => {{}}
+                        window.$RefreshSig$ = () => (type) => type
+                        window.__vite_plugin_react_preamble_installed__ = true
+                    </script>
+                    "#,
+            ));
+        }
 
         entrypoints
             .iter()


### PR DESCRIPTION
Made a couple of minor changes to import resolution and development HTML generation to support React apps.

**Import Resolution**
When Vite builds the React files it does not transform the key entries from `jsx` to `js`.  Previously in-vite was missing entires for `jsx` files when resolving imports causing the js code to not be loaded by the page.

**Development HTML**
When running a React app in development Vite expects there to be a React preamble module loaded and reports an error in the browser if it is missing. This change checks to see if there is a file ending in `.jsx` present in the entrypoints and inserts the React preamble if a `.jsx` file is found.