### PR TITLE
fix: Support TypeScript module imports

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -95,7 +95,7 @@ impl<'a> Manifest {
 
         if key.ends_with(".css") {
             resources.push(Resource::Stylesheet(&chunk.file));
-        } else if key.ends_with(".js") || key.ends_with(".jsx") {
+        } else if key.ends_with(".js") || key.ends_with(".jsx") || key.ends_with(".ts") || key.ends_with(".tsx") {
             resources.push(Resource::Module(&chunk.file));
         }
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -20,10 +20,10 @@ impl<'a> Resource<'a> {
     /// the resource.
     pub fn to_html(&'a self) -> String {
         match *self {
-            Self::Stylesheet(uri) => format!(r#"<link rel="stylesheet" href="{uri}" />"#),
-            Self::Module(uri) => format!(r#"<script type="module" src="{uri}"></script>"#),
+            Self::Stylesheet(uri) => format!(r#"<link rel="stylesheet" href="/{uri}" />"#),
+            Self::Module(uri) => format!(r#"<script type="module" src="/{uri}"></script>"#),
             Self::PreloadModule(uri) => {
-                format!(r#"<link rel="modulepreload" href="{uri}" />"#)
+                format!(r#"<link rel="modulepreload" href="/{uri}" />"#)
             }
         }
     }


### PR DESCRIPTION
Fixes: #6
Adds support for importing TypeScript modules (`.ts` and `.tsx` files) in the manifest, enabling their inclusion in the build process.